### PR TITLE
Fix command sent by CommandMinecart

### DIFF
--- a/src/main/java/dev/esophose/playerparticles/manager/CommandManager.java
+++ b/src/main/java/dev/esophose/playerparticles/manager/CommandManager.java
@@ -39,6 +39,7 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.minecart.CommandMinecart;
 
 public class CommandManager extends Manager implements CommandExecutor, TabCompleter {
 
@@ -160,7 +161,7 @@ public class CommandManager extends Manager implements CommandExecutor, TabCompl
                         sender.sendMessage(ChatColor.RED + "Error: This command can only be executed by a player.");
                         return;
                     }
-                } else if (sender instanceof ConsoleCommandSender || sender instanceof BlockCommandSender) {
+                } else if (sender instanceof ConsoleCommandSender || sender instanceof BlockCommandSender || sender instanceof CommandMinecart) {
                     commandModule.onCommandExecute(PlayerParticlesAPI.getInstance().getConsolePPlayer(), cmdArgs);
                     return;
                 }


### PR DESCRIPTION
When using something like `Bukkit.dispatchCommand(commandMinecartEntity, "pp reset " + player.getName())`, the plugin throws an error :
```
[23:58:28] [Craft Scheduler Thread - 1841 - PlayerParticles/WARN]: [PlayerParticles] Plugin PlayerParticles v8.2 generated an exception while executing task 4682981
java.lang.ClassCastException: class org.bukkit.craftbukkit.v1_19_R1.entity.CraftMinecartCommand cannot be cast to class org.bukkit.entity.Player (org.bukkit.craftbukkit.v1_19_R1.entity.CraftMinecartCommand and org.bukkit.entity.Player are in unnamed module of loader java.net.URLClassLoader @a7e666)
at dev.esophose.playerparticles.manager.CommandManager.lambda$onCommand$1(CommandManager.java:168) ~[PlayerParticles-8.2.jar:?]
at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftTask.run(CraftTask.java:101) ~[paper-1.19.2.jar:git-Paper-173]
at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[paper-1.19.2.jar:git-Paper-173]
at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[paper-1.19.2.jar:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

Here is a fix.