### PR TITLE
Add disable-crit-particles and crit-only options to Arrow particle style

### DIFF
--- a/src/main/java/dev/esophose/playerparticles/styles/ParticleStyleArrows.java
+++ b/src/main/java/dev/esophose/playerparticles/styles/ParticleStyleArrows.java
@@ -108,9 +108,9 @@ public class ParticleStyleArrows extends ConfiguredParticleStyle implements List
             if (this.disableCritParticles && event.getEntity() instanceof AbstractArrow) {
                 AbstractArrow arrow = (AbstractArrow) event.getEntity();
                 isCritical = arrow.isCritical();
-                if (this.criticalOnly && !isCritical) {
+                if (this.criticalOnly && !isCritical)
                     return;
-                }
+                
                 arrow.setCritical(false);
             }
             
@@ -126,15 +126,16 @@ public class ParticleStyleArrows extends ConfiguredParticleStyle implements List
      */
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onProjectileHit(ProjectileHitEvent event) {
-        if (!(event.getEntity() instanceof AbstractArrow)) {
+        if (!this.disableCritParticles)
             return;
-        }
+        
+        if (!(event.getEntity() instanceof AbstractArrow))
+            return;
         
         AbstractArrow arrow = (AbstractArrow) event.getEntity();
         for (LaunchedProjectile launchedProjectile : this.projectiles) {
-            if (!launchedProjectile.getProjectile().equals(arrow)) {
+            if (!launchedProjectile.getProjectile().equals(arrow))
                 continue;
-            }
             
             arrow.setCritical(launchedProjectile.isCritical());
             break;

--- a/src/main/java/dev/esophose/playerparticles/styles/ParticleStyleArrows.java
+++ b/src/main/java/dev/esophose/playerparticles/styles/ParticleStyleArrows.java
@@ -148,7 +148,7 @@ public class ParticleStyleArrows extends ConfiguredParticleStyle implements List
         this.setIfNotExists("arrow-entities", Arrays.asList("ARROW", "SPECTRAL_ARROW", "TIPPED_ARROW"), "The name of the projectile entities that are counted as arrows");
         this.setIfNotExists("arrow-tracking-time", 1200, "The maximum number of ticks to track an arrow for", "Set to -1 to disable (not recommended)");
         this.setIfNotExists("disable-crit-particles", false, "Disable vanilla critical particles of crossbow/fully", "charged bow arrows to make the trail more visible");
-        this.setIfNotExists("critical-only", false, "Only show particles on arrows when they are critical", "Requires disable-crit-particles = true.");
+        this.setIfNotExists("critical-only", false, "Only show particles on arrows when they are critical", "Requires disable-crit-particles: true.");
     }
 
     @Override


### PR DESCRIPTION
Vanilla clients render critical particles on arrows that are shot from crossbows or fully charged bows. This can interfere with projectile trails and make them look unclean. I have added 2 options to fix this:
- `disable-crit-particles`: Disables vanilla critical particles and only render the projectile trail
- `critical-only`: Requires `disable-crit-particles: true`. Only render projectile trails on arrows when they are critical. This effectively replaces the critical particles with the custom projectile trail.

Aside from adding particles in vanilla, critical arrows also do more damage. Because this feature works by setting all arrows `setCritical(false)`, an additional listener for `ProjectileHitEvent` restores the criticality and thus the damage behavior. These are the only 2 effects of critical arrows as per the [Wiki](https://minecraft.wiki/w/Arrow#Damage).

Both features have been tested and verified working, and damage behaves as expected to vanilla values.